### PR TITLE
Hotfix/httpx

### DIFF
--- a/pyfivetran/client.py
+++ b/pyfivetran/client.py
@@ -28,12 +28,12 @@ class FivetranClient:
     Interface class for Fivetran API interactions via endpoints.
     """
 
-    def __init__(self, api_key: str, api_secret: str) -> None:
+    def __init__(self, api_key: str, api_secret: str, **httpx_kwargs) -> None:
         if not api_key or not api_secret:
             raise ValueError("api_key and api_secret are required")
         self.api_key = api_key
         self.api_secret = api_secret
-        self._client = httpx.Client()
+        self._client = httpx.Client(**httpx_kwargs)
 
     @lazy
     def account_info(self) -> GeneralApiResponse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfivetran"
-version = "2024.03.04.02"
+version = "2024.03.04.03"
 description = "Pythonic interface to the fivetran API"
 authors = ["Khari Gardner <kharigardner@protonmail.com>"]
 license = "MIT"


### PR DESCRIPTION
HTTPX has a default timeout of `5s`, which is unacceptable. Add a `httpx_kwargs` parameter to Fivetran Client intialization to allow for customization of HTTPX client.