### PR TITLE
Release/2024.03.05.01

### DIFF
--- a/pyfivetran/shed.py
+++ b/pyfivetran/shed.py
@@ -11,7 +11,7 @@ class GeneralApiResponse(TypedDict):
     data: Optional[Dict[str, Any]]
     
 class ApiError(Exception):
-    def __inti__(self, msg: str):
+    def __init__(self, msg: str):
         self.msg = msg
 
     def __str__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfivetran"
-version = "2024.03.04.03"
+version = "2024.03.05.01"
 description = "Pythonic interface to the fivetran API"
 authors = ["Khari Gardner <kharigardner@protonmail.com>"]
 license = "MIT"


### PR DESCRIPTION
**Nightly Release v2024.03.05.01**

- Fixed `ApiError` intialization typo which was causing attributes to not be assigned upon creation and can lead to unexpected `ValueError` instead of `ApiError`